### PR TITLE
Fix property typo in turn-based pathfinding

### DIFF
--- a/Noexia.AI.DecisionMaking.TurnBased/Pathfinding.cs
+++ b/Noexia.AI.DecisionMaking.TurnBased/Pathfinding.cs
@@ -40,7 +40,7 @@ namespace Noexia.AI.DecisionMaking.TurnBased
 
 				CellState nextCell = a_map.GetCell(nextX, nextY);
 
-				if (nextCell.IsWalabke)
+                                if (nextCell.IsWalkable)
 				{
 					currentCell = nextCell;
 				}

--- a/Noexia.AI.DecisionMaking.TurnBased/States/CellState.cs
+++ b/Noexia.AI.DecisionMaking.TurnBased/States/CellState.cs
@@ -12,7 +12,7 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 		private readonly CellData m_cellData;
 		public int CharacterId { get; private set; } = 0;
 		private bool m_isWalkable = true;
-		public bool IsWalabke => m_cellData.isWalkable && m_isWalkable;
+                public bool IsWalkable => m_cellData.isWalkable && m_isWalkable;
 		public int X => m_cellData.x;
 		public int Y => m_cellData.y;
 		public int Id => m_cellData.id;
@@ -55,9 +55,9 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 			return true;
 		}
 
-		public CellState Clone()
-		{
-			return new CellState(m_cellData, CharacterId, IsWalabke);
-		}
+                public CellState Clone()
+                {
+                        return new CellState(m_cellData, CharacterId, IsWalkable);
+                }
 	}
 }

--- a/Noexia.AI.DecisionMaking.TurnBased/States/MapState.cs
+++ b/Noexia.AI.DecisionMaking.TurnBased/States/MapState.cs
@@ -104,8 +104,8 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 			int left = a_startX - 1;
 			if (left >= 0)
 			{
-				CellState leftCell = m_cells[left, a_startY];
-				if (a_walkable == false || leftCell.IsWalabke)
+                                CellState leftCell = m_cells[left, a_startY];
+                                if (a_walkable == false || leftCell.IsWalkable)
 				{
 					cells.Add(m_cells[left, a_startY]);
 				}
@@ -114,8 +114,8 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 			int right = a_startX + 1;
 			if (right < Width)
 			{
-				CellState rightCell = m_cells[right, a_startY];
-				if (a_walkable == false || rightCell.IsWalabke)
+                                CellState rightCell = m_cells[right, a_startY];
+                                if (a_walkable == false || rightCell.IsWalkable)
 				{
 					cells.Add(m_cells[right, a_startY]);
 				}
@@ -124,7 +124,7 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 			int up = a_startY - 1;
 			if (up >= 0)
 			{
-				if (a_walkable == false || m_cells[a_startX, up].IsWalabke)
+                                if (a_walkable == false || m_cells[a_startX, up].IsWalkable)
 				{
 					cells.Add(m_cells[a_startX, up]);
 				}
@@ -133,7 +133,7 @@ namespace Noexia.AI.DecisionMaking.TurnBased.States
 			int down = a_startY + 1;
 			if (down < Height)
 			{
-				if (a_walkable == false || m_cells[a_startX, down].IsWalabke)
+                                if (a_walkable == false || m_cells[a_startX, down].IsWalkable)
 				{
 					cells.Add(m_cells[a_startX, down]);
 				}


### PR DESCRIPTION
## Summary
- fix typo `IsWalabke` -> `IsWalkable`
- update property usages

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6861ac8415508325be6fe342ee283a02