### PR TITLE
Fix diagonal push check

### DIFF
--- a/Noexia.AI.DecisionMaking.TurnBased/Pathfinding.cs
+++ b/Noexia.AI.DecisionMaking.TurnBased/Pathfinding.cs
@@ -21,11 +21,10 @@ namespace Noexia.AI.DecisionMaking.TurnBased
 			int dirX = Math.Sign(a_from.X - a_pusher.X);
 			int dirY = Math.Sign(a_from.Y - a_pusher.Y);
 
-			if ((dirX == 1 && dirY == 0)
-				|| (dirX == -1 && dirY == 0)
-				|| (dirX == 0 && dirY == 1)
-				|| (dirX == 0 && dirY == -1)
-				== false)
+                        if (!((dirX == 1 && dirY == 0)
+                                || (dirX == -1 && dirY == 0)
+                                || (dirX == 0 && dirY == 1)
+                                || (dirX == 0 && dirY == -1)))
 			{
 				return new PushResult { Destination = a_from, CellsBlocked = 0 }; // pas de diagonale
 			}


### PR DESCRIPTION
## Summary
- ensure Pathfinding rejects diagonal push directions

## Testing
- `dotnet test Noexia.AI.DecisionMaking.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6861ae8d2c0083259a3fb2fdb442c7ac