### PR TITLE
Add enemy potential damage evaluation

### DIFF
--- a/Noexia.AI.DecisionMaking/MiniMaxDecisionMaker.cs
+++ b/Noexia.AI.DecisionMaking/MiniMaxDecisionMaker.cs
@@ -9,35 +9,48 @@ namespace Noexia.AI.DecisionMaking
 	public class MiniMaxDecisionMaker<T> : DecisionMaker<T>
 		where T : MomentaryState
 	{
-		public override T? MakeDecision(T a_state, ref int a_totalIterations, ref T a_bestState)
-		{
-			T? bestState = a_bestState;
+                public override T? MakeDecision(T a_state, ref int a_totalIterations, ref T a_bestState)
+                {
+                        T? bestState = a_bestState;
 
-			IEnumerable<IAction> actions = a_state.GetNextLegalActions();
-            foreach (var action in actions)
-            {
-				T state = (T)a_state.Clone();
-				state.Apply(action);
-				a_totalIterations++;
+                        var actions = a_state.GetNextLegalActions().ToList();
 
-				if (bestState == null || state.TotalScore > bestState.TotalScore ||
-					(state.TotalScore == bestState.TotalScore && state.Actions.Count < bestState.Actions.Count))
-				{
-					bestState = state;
-				}
+                        if (actions.Count == 0)
+                        {
+                                a_state.FinalizeState();
 
-				T? result = MakeDecision(state, ref a_totalIterations, ref bestState);
-				if (result != null && (bestState == null || result.TotalScore > bestState.TotalScore ||
-						(result.TotalScore == bestState.TotalScore && result.Actions.Count < bestState.Actions.Count)))
-				{
-					bestState = result;
-				}
+                                if (bestState == null || a_state.TotalScore > bestState.TotalScore ||
+                                        (a_state.TotalScore == bestState.TotalScore && a_state.Actions.Count < bestState.Actions.Count))
+                                {
+                                        bestState = a_state;
+                                }
 
-				a_bestState = bestState ?? a_bestState;
-				return bestState;
-			}
+                                a_bestState = bestState ?? a_bestState;
+                                return bestState;
+                        }
 
-			return bestState;
-		}
+                        foreach (var action in actions)
+                        {
+                                T state = (T)a_state.Clone();
+                                state.Apply(action);
+                                a_totalIterations++;
+
+                                if (bestState == null || state.TotalScore > bestState.TotalScore ||
+                                        (state.TotalScore == bestState.TotalScore && state.Actions.Count < bestState.Actions.Count))
+                                {
+                                        bestState = state;
+                                }
+
+                                T? result = MakeDecision(state, ref a_totalIterations, ref bestState);
+                                if (result != null && (bestState == null || result.TotalScore > bestState.TotalScore ||
+                                                (result.TotalScore == bestState.TotalScore && result.Actions.Count < bestState.Actions.Count)))
+                                {
+                                        bestState = result;
+                                }
+                        }
+
+                        a_bestState = bestState ?? a_bestState;
+                        return bestState;
+                }
 	}
 }

--- a/Noexia.AI.DecisionMaking/MomentaryState.cs
+++ b/Noexia.AI.DecisionMaking/MomentaryState.cs
@@ -6,15 +6,21 @@ using System.Threading.Tasks;
 
 namespace Noexia.AI.DecisionMaking
 {
-	public abstract class MomentaryState
-	{
-		protected List<IAction> m_actions = new();
-		public IReadOnlyList<IAction> Actions => m_actions;
-		public int TotalScore { get; protected set; } = 0;
-		public int Score { get; protected set; } = 0;
+        public abstract class MomentaryState
+        {
+                protected List<IAction> m_actions = new();
+                public IReadOnlyList<IAction> Actions => m_actions;
+                public int TotalScore { get; protected set; } = 0;
+                public int Score { get; protected set; } = 0;
 
-		public abstract IEnumerable<IAction> GetNextLegalActions();
-		public abstract bool Apply(IAction a_action);
-		public abstract MomentaryState Clone();
-	}
+                public abstract IEnumerable<IAction> GetNextLegalActions();
+                public abstract bool Apply(IAction a_action);
+                public abstract MomentaryState Clone();
+
+                /// <summary>
+                /// Called when no more actions can be applied on this state in order to
+                /// finalize the score computation. Default implementation does nothing.
+                /// </summary>
+                public virtual void FinalizeState() { }
+        }
 }


### PR DESCRIPTION
## Summary
- add `FinalizeState` hook in `MomentaryState`
- evaluate enemies' potential damage and penalize final state in `GameState`
- compute this penalty when no more actions are available in `MiniMaxDecisionMaker`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7c0e130832589fe5d56a39dbb94